### PR TITLE
Fix for issue that prevents using the module with any other language than 'ro' or 'en'

### DIFF
--- a/woocommerce/vendor/banca-transilvania/ipay-sdk/src/Config/Config.php
+++ b/woocommerce/vendor/banca-transilvania/ipay-sdk/src/Config/Config.php
@@ -169,7 +169,7 @@ class Config
 
         $validLanguages = [self::ROMANIAN_LANGUAGE, self::ENGLISH_LANGUAGE];
         if (!in_array($value, $validLanguages, true)) {
-            return $this->language;
+            $value = self::ENGLISH_LANGUAGE;
         }
 
         $this->language = $value;

--- a/woocommerce/vendor/banca-transilvania/ipay-sdk/src/Config/Config.php
+++ b/woocommerce/vendor/banca-transilvania/ipay-sdk/src/Config/Config.php
@@ -169,7 +169,7 @@ class Config
 
         $validLanguages = [self::ROMANIAN_LANGUAGE, self::ENGLISH_LANGUAGE];
         if (!in_array($value, $validLanguages, true)) {
-            throw new \InvalidArgumentException("Invalid language value: '$value'.");
+            return $this->language;
         }
 
         $this->language = $value;


### PR DESCRIPTION
Throwing an exception when the site language is not in the `$validLanguages` array prevents using the module with any other language.
Shouldn't prevent this functionality, when the language is not one of the valid ones, let the payment process with the default language.