### PR TITLE
Fix refund amount formatting: use round() instead of number_format()

### DIFF
--- a/woocommerce/includes/payment/class-bt-ipay-gateway.php
+++ b/woocommerce/includes/payment/class-bt-ipay-gateway.php
@@ -166,7 +166,7 @@ class Bt_Ipay_Gateway extends WC_Payment_Gateway {
 		return (
 			new Bt_Ipay_Refund_Processor(
 				(int) $order_id,
-				number_format( floatval( $amount ), 2 )
+				round( floatval( $amount ), 2 )
 			)
 		)->process();
 	}

--- a/woocommerce/includes/refund/class-bt-ipay-refund-processor.php
+++ b/woocommerce/includes/refund/class-bt-ipay-refund-processor.php
@@ -43,7 +43,7 @@ class Bt_Ipay_Refund_Processor {
 			$result         = new Bt_Ipay_Refund_Result();
 			$refund_service = new Bt_Ipay_Refund(
 				$payment_engine_id,
-				number_format( floatval( $this->amount ), 2 ),
+				round( floatval( $this->amount ), 2 ),
 				$result
 			);
 

--- a/woocommerce_digital_products/includes/payment/class-bt-ipay-gateway.php
+++ b/woocommerce_digital_products/includes/payment/class-bt-ipay-gateway.php
@@ -166,7 +166,7 @@ class Bt_Ipay_Gateway extends WC_Payment_Gateway {
 		return (
 			new Bt_Ipay_Refund_Processor(
 				(int) $order_id,
-				number_format( floatval( $amount ), 2 )
+				round( floatval( $amount ), 2 )
 			)
 		)->process();
 	}

--- a/woocommerce_digital_products/includes/refund/class-bt-ipay-refund-processor.php
+++ b/woocommerce_digital_products/includes/refund/class-bt-ipay-refund-processor.php
@@ -43,7 +43,7 @@ class Bt_Ipay_Refund_Processor {
 			$result         = new Bt_Ipay_Refund_Result();
 			$refund_service = new Bt_Ipay_Refund(
 				$payment_engine_id,
-				number_format( floatval( $this->amount ), 2 ),
+				round( floatval( $this->amount ), 2 ),
 				$result
 			);
 


### PR DESCRIPTION
## Problem

`number_format( floatval( $amount ), 2 )` produces a locale-formatted **string** with a thousands separator (e.g. `1,234.50`). When that value is forwarded to the iPay refund SDK, the comma corrupts the amount for any refund of 1000 or more.

## Fix

Use `round( floatval( $amount ), 2 )`, which returns a clean numeric value with no grouping separator.

Applied in both trees:
- `woocommerce/` — `includes/payment/class-bt-ipay-gateway.php`, `includes/refund/class-bt-ipay-refund-processor.php`
- `woocommerce_digital_products/` — same two files

No behavior change for amounts under 1000.