### PR TITLE
Fix: populate and guard payment amount on APPROVED callback

### DIFF
--- a/woocommerce/includes/sdk/class-bt-ipay-sdk-detail-response.php
+++ b/woocommerce/includes/sdk/class-bt-ipay-sdk-detail-response.php
@@ -95,8 +95,8 @@ class Bt_Ipay_Sdk_Detail_Response {
 	}
 
 	public function get_amount(): float {
-		if ( is_int( $this->response->amount ) ) {
-			return $this->response->amount / 100;
+		if ( is_numeric( $this->response->amount ) ) {
+			return ( (int) $this->response->amount ) / 100;
 		}
 		return 0.0;
 	}

--- a/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -129,6 +129,19 @@ class Bt_Ipay_Webhook_Processor {
 			/* translators: %s: payment status */
 			sprintf( esc_html__( 'Received loy status: `%s` via callback', 'bt-ipay-payments' ), esc_attr( $payment_status ) )
 		);
+
+		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
+			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
+			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_data['ipay_id'] ) );
+
+			$this->payment_storage->update_loy_status_and_amount(
+				$payment_data['ipay_id'],
+				$payment_status,
+				$payment_details->get_loy_amount()
+			);
+			return;
+		}
+
 		$this->payment_storage->update_loy_status( $payment_data['ipay_id'], $payment_status );
 	}
 
@@ -294,6 +307,18 @@ class Bt_Ipay_Webhook_Processor {
 			$this->has_failed()
 		) {
 			$payment_status = Bt_Ipay_Payment_Storage::STATUS_DECLINED;
+		}
+
+		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
+			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
+			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_engine_id ) );
+
+			$this->payment_storage->update_status_and_amount(
+				$payment_engine_id,
+				$payment_status,
+				$payment_details->get_amount()
+			);
+			return;
 		}
 
 		$this->payment_storage->update_status(

--- a/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -203,9 +203,9 @@ class Bt_Ipay_Webhook_Processor {
 		if ( $total_captured > 0 ) {
 			if ( $is_loy ) {
 				$this->payment_storage->update_loy_status_and_amount(
-					$payment_data['loy_id'],
+					$payment_data['ipay_id'],
 					Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
-					$total_captured
+					$payment_details->get_loy_amount()
 				);
 			} else {
 				$this->payment_storage->update_status_and_amount(

--- a/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -133,13 +133,16 @@ class Bt_Ipay_Webhook_Processor {
 		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
 			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
 			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_data['ipay_id'] ) );
+			$loy_amount      = $payment_details->get_loy_amount();
 
-			$this->payment_storage->update_loy_status_and_amount(
-				$payment_data['ipay_id'],
-				$payment_status,
-				$payment_details->get_loy_amount()
-			);
-			return;
+			if ( $payment_details->is_successful() && $loy_amount > 0 ) {
+				$this->payment_storage->update_loy_status_and_amount(
+					$payment_data['ipay_id'],
+					$payment_status,
+					$loy_amount
+				);
+				return;
+			}
 		}
 
 		$this->payment_storage->update_loy_status( $payment_data['ipay_id'], $payment_status );
@@ -316,13 +319,16 @@ class Bt_Ipay_Webhook_Processor {
 		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
 			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
 			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_engine_id ) );
+			$amount          = $payment_details->get_amount();
 
-			$this->payment_storage->update_status_and_amount(
-				$payment_engine_id,
-				$payment_status,
-				$payment_details->get_amount()
-			);
-			return;
+			if ( $payment_details->is_successful() && $amount > 0 ) {
+				$this->payment_storage->update_status_and_amount(
+					$payment_engine_id,
+					$payment_status,
+					$amount
+				);
+				return;
+			}
 		}
 
 		$this->payment_storage->update_status(

--- a/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -199,29 +199,33 @@ class Bt_Ipay_Webhook_Processor {
 		$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
 		$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_data['ipay_id'] ) );
 
-		$total_captured = $payment_details->get_total_available();
-		if ( $total_captured > 0 ) {
-			if ( $is_loy ) {
+		if ( $is_loy ) {
+			$loy_captured = $payment_details->get_loy_amount();
+			if ( $loy_captured > 0 ) {
 				$this->payment_storage->update_loy_status_and_amount(
 					$payment_data['ipay_id'],
 					Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
-					$payment_details->get_loy_amount()
+					$loy_captured
 				);
-			} else {
-				$this->payment_storage->update_status_and_amount(
-					$payment_data['ipay_id'],
-					Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
-					$total_captured
-				);
-
-				if (
-					isset( $payment_data['loy_status'], $payment_data['loy_amount'] ) &&
-					$payment_data['loy_status'] === Bt_Ipay_Payment_Storage::STATUS_DEPOSITED
-				) {//add the loy captured amount
-					$total_captured += floatval( $payment_data['loy_amount'] );
-				}
-				$this->deduct_not_captured( $total_captured, $order_service );
 			}
+			return;
+		}
+
+		$total_captured = $payment_details->get_total_available();
+		if ( $total_captured > 0 ) {
+			$this->payment_storage->update_status_and_amount(
+				$payment_data['ipay_id'],
+				Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
+				$total_captured
+			);
+
+			if (
+				isset( $payment_data['loy_status'], $payment_data['loy_amount'] ) &&
+				$payment_data['loy_status'] === Bt_Ipay_Payment_Storage::STATUS_DEPOSITED
+			) {//add the loy captured amount
+				$total_captured += floatval( $payment_data['loy_amount'] );
+			}
+			$this->deduct_not_captured( $total_captured, $order_service );
 		}
 	}
 

--- a/woocommerce_digital_products/includes/sdk/class-bt-ipay-sdk-detail-response.php
+++ b/woocommerce_digital_products/includes/sdk/class-bt-ipay-sdk-detail-response.php
@@ -95,8 +95,8 @@ class Bt_Ipay_Sdk_Detail_Response {
 	}
 
 	public function get_amount(): float {
-		if ( is_int( $this->response->amount ) ) {
-			return $this->response->amount / 100;
+		if ( is_numeric( $this->response->amount ) ) {
+			return ( (int) $this->response->amount ) / 100;
 		}
 		return 0.0;
 	}

--- a/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -203,9 +203,9 @@ class Bt_Ipay_Webhook_Processor {
 		if ( $total_captured > 0 ) {
 			if ( $is_loy ) {
 				$this->payment_storage->update_loy_status_and_amount(
-					$payment_data['loy_id'],
+					$payment_data['ipay_id'],
 					Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
-					$total_captured
+					$payment_details->get_loy_amount()
 				);
 			} else {
 				$this->payment_storage->update_status_and_amount(

--- a/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -133,13 +133,16 @@ class Bt_Ipay_Webhook_Processor {
 		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
 			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
 			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_data['ipay_id'] ) );
+			$loy_amount      = $payment_details->get_loy_amount();
 
-			$this->payment_storage->update_loy_status_and_amount(
-				$payment_data['ipay_id'],
-				$payment_status,
-				$payment_details->get_loy_amount()
-			);
-			return;
+			if ( $payment_details->is_successful() && $loy_amount > 0 ) {
+				$this->payment_storage->update_loy_status_and_amount(
+					$payment_data['ipay_id'],
+					$payment_status,
+					$loy_amount
+				);
+				return;
+			}
 		}
 
 		$this->payment_storage->update_loy_status( $payment_data['ipay_id'], $payment_status );
@@ -314,13 +317,16 @@ class Bt_Ipay_Webhook_Processor {
 		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
 			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
 			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_engine_id ) );
+			$amount          = $payment_details->get_amount();
 
-			$this->payment_storage->update_status_and_amount(
-				$payment_engine_id,
-				$payment_status,
-				$payment_details->get_amount()
-			);
-			return;
+			if ( $payment_details->is_successful() && $amount > 0 ) {
+				$this->payment_storage->update_status_and_amount(
+					$payment_engine_id,
+					$payment_status,
+					$amount
+				);
+				return;
+			}
 		}
 
 		$this->payment_storage->update_status(

--- a/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -129,6 +129,19 @@ class Bt_Ipay_Webhook_Processor {
 			/* translators: %s: payment status */
 			sprintf( esc_html__( 'Received loy status: `%s` via callback', 'bt-ipay-payments' ), esc_attr( $payment_status ) )
 		);
+
+		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
+			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
+			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_data['ipay_id'] ) );
+
+			$this->payment_storage->update_loy_status_and_amount(
+				$payment_data['ipay_id'],
+				$payment_status,
+				$payment_details->get_loy_amount()
+			);
+			return;
+		}
+
 		$this->payment_storage->update_loy_status( $payment_data['ipay_id'], $payment_status );
 	}
 
@@ -292,6 +305,18 @@ class Bt_Ipay_Webhook_Processor {
 			$this->has_failed()
 		) {
 			$payment_status = Bt_Ipay_Payment_Storage::STATUS_DECLINED;
+		}
+
+		if ( $payment_status === Bt_Ipay_Payment_Storage::STATUS_APPROVED ) {
+			$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
+			$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_engine_id ) );
+
+			$this->payment_storage->update_status_and_amount(
+				$payment_engine_id,
+				$payment_status,
+				$payment_details->get_amount()
+			);
+			return;
 		}
 
 		$this->payment_storage->update_status(

--- a/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
+++ b/woocommerce_digital_products/includes/webhook/class-bt-ipay-webhook-processor.php
@@ -199,29 +199,33 @@ class Bt_Ipay_Webhook_Processor {
 		$client          = new Bt_Ipay_Sdk_Client( new Bt_Ipay_Config() );
 		$payment_details = $client->payment_details( new Bt_Ipay_Sdk_Common_Payload( $payment_data['ipay_id'] ) );
 
-		$total_captured = $payment_details->get_total_available();
-		if ( $total_captured > 0 ) {
-			if ( $is_loy ) {
+		if ( $is_loy ) {
+			$loy_captured = $payment_details->get_loy_amount();
+			if ( $loy_captured > 0 ) {
 				$this->payment_storage->update_loy_status_and_amount(
 					$payment_data['ipay_id'],
 					Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
-					$payment_details->get_loy_amount()
+					$loy_captured
 				);
-			} else {
-				$this->payment_storage->update_status_and_amount(
-					$payment_data['ipay_id'],
-					Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
-					$total_captured
-				);
-
-				if (
-					isset( $payment_data['loy_status'], $payment_data['loy_amount'] ) &&
-					$payment_data['loy_status'] === Bt_Ipay_Payment_Storage::STATUS_DEPOSITED
-				) {//add the loy captured amount
-					$total_captured += floatval( $payment_data['loy_amount'] );
-				}
-				$this->deduct_not_captured( $total_captured, $order_service );
 			}
+			return;
+		}
+
+		$total_captured = $payment_details->get_total_available();
+		if ( $total_captured > 0 ) {
+			$this->payment_storage->update_status_and_amount(
+				$payment_data['ipay_id'],
+				Bt_Ipay_Payment_Storage::STATUS_DEPOSITED,
+				$total_captured
+			);
+
+			if (
+				isset( $payment_data['loy_status'], $payment_data['loy_amount'] ) &&
+				$payment_data['loy_status'] === Bt_Ipay_Payment_Storage::STATUS_DEPOSITED
+			) {//add the loy captured amount
+				$total_captured += floatval( $payment_data['loy_amount'] );
+			}
+			$this->deduct_not_captured( $total_captured, $order_service );
 		}
 	}
 


### PR DESCRIPTION
## Problem

Reported for the **Authorize** payment flow: after the buyer confirms the payment at iPay but closes the tab **before** reaching the thank-you page, the return handler that normally calls `getOrderStatusExtended.do` and stores the amount never runs. The payment row stays at `CREATED` / amount `0.00`.

The subsequent iPay **callback** then flips the status to `APPROVED` but leaves the amount at `0.00`, so the merchant cannot capture the transaction.

This affects all iPay modules.

## Fixes

**1. Populate the amount on an `APPROVED` callback.** The webhook processor now calls `getOrderStatusExtended.do` on an `APPROVED` callback and persists the amount, mirroring the finish (thank-you) processor:

- **Card leg** — `update_payment_status()` stores the authorized amount via `update_status_and_amount()`.
- **Loyalty leg** — `update_loy_data()` stores the loyalty amount (`loyaltyAmount` from the card leg's status response) via `update_loy_status_and_amount()`.

Failed authorizations (`status != 1`) are still downgraded to `DECLINED` and record no amount; the `REFUNDED` path is unchanged.

**2. Fix `capture()` loyalty-leg persistence (pre-existing bug found while fixing the above).** The DEPOSITED capture path stored the loyalty leg via `update_loy_status_and_amount( $payment_data['loy_id'], ... )`, but that method filters `WHERE ipay_id = ?`. A split payment is a single row keyed by the card `ipay_id` (`loy_id` is only a column on that row), so the update matched no row and the loyalty capture was silently dropped. It also passed the card leg's deposited total (`get_total_available()`) as the loyalty amount. Both are now aligned with the admin capture flow and finish processor: key by `ipay_id`, store `get_loy_amount()`.

**3. Gate each `capture()` leg on its own amount.** Previously both legs shared one guard driven by the card leg's `get_total_available()`, so a loyalty-only capture (card available `0`) would skip persisting the loyalty leg. The loyalty leg is now gated on `get_loy_amount()`, the card leg on `get_total_available()`.

**4. Guard the `APPROVED` amount population against a failed/empty detail fetch.** The amount/`loy_amount` is now written only when the `getOrderStatusExtended.do` fetch succeeded (`is_successful()`) **and** the amount is `> 0`, mirroring `capture()`'s gating. Otherwise the processor falls through to the status-only update, so a failed or empty fetch can no longer clobber an amount already stored by the finish processor. `Bt_Ipay_Sdk_Detail_Response::get_amount()` was also made tolerant of numeric-string amounts (`is_numeric` + `int` cast instead of strict `is_int`), so a quoted amount is no longer silently dropped to `0`.

All applied to both the `woocommerce/` and `woocommerce_digital_products/` trees.

## Verification

- **Unit tests** (red → green), 19 assertions across both trees, covering: APPROVED card leg populates amount; failed auth records no amount; DEPOSITED card leg still captures; APPROVED loyalty leg populates `loy_amount`; DEPOSITED loyalty-leg capture targets the correct row with the correct amount; and loyalty-leg capture works when the card leg's available is `0`.
- **Live end-to-end** on a local sandbox store: registered a real Authorize pre-auth (row `CREATED` / `0.00`), then POSTed a signed callback (`operation=approved`) to the webhook → row became `APPROVED` / `79.98` and the order moved to `on-hold`. (The loyalty-leg paths are covered by unit tests; the sandbox has no loyalty card/points to exercise them live.)
