### PR TITLE
Declare WooCommerce 11 compatibility, bump to 1.0.7

### DIFF
--- a/woocommerce/README.txt
+++ b/woocommerce/README.txt
@@ -5,7 +5,7 @@ Tags: payment, banca transilvania
 Requires at least: 5.9
 Requires PHP: 8.1
 Tested up to: 6.9.1
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ Pentru detalii aplicatiiecommerce@btrl.ro
 1. Settings page
 2. Payment page
 == Changelog ==
+= 1.0.7 =
+Compatibilitate declarată cu WooCommerce 11 și cu Checkout-ul pe blocuri (Cart & Checkout Blocks).
 = 1.0 =
 Initial release
 == Upgrade Notice ==

--- a/woocommerce/bt-ipay-payments.php
+++ b/woocommerce/bt-ipay-payments.php
@@ -16,7 +16,7 @@
  * Plugin Name:       BT iPay Payments
  * Plugin URI:        https://btepos.ro/module-ecommerce
  * Description:       Extinde WooCommerce cu plata prin <strong>iPay BT</strong>. Pentru conectare aveti nevoie de credentiale API de la Banca Transilvania. Pentru detalii aplicatiiecommerce@btrl.ro
- * Version:           1.0.6
+ * Version:           1.0.7
  * Author:            Banca Transilvania
  * Author URI:        https://btepos.ro/module-ecommerce/
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@
  * Domain Path:       /languages
  * Requires Plugins:  woocommerce
  * WC requires at least: 7.0
- * WC tested up to: 8.7
+ * WC tested up to: 11.0
  */
 
 // If this file is called directly, abort.
@@ -38,7 +38,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'BT_IPAY_VERSION', '1.0.6' );
+define( 'BT_IPAY_VERSION', '1.0.7' );
 
 define( 'BT_IPAY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
@@ -90,6 +90,7 @@ bt_ipay_run();
 add_action( 'before_woocommerce_init', function() {
 	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
 	}
 } );
 

--- a/woocommerce_digital_products/README.txt
+++ b/woocommerce_digital_products/README.txt
@@ -5,7 +5,7 @@ Tags: payment, banca transilvania
 Requires at least: 5.9
 Requires PHP: 8.1
 Tested up to: 6.9.1
-Stable tag: 1.0.3
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ Pentru detalii aplicatiiecommerce@btrl.ro
 1. Settings page
 2. Payment page
 == Changelog ==
+= 1.0.7 =
+Compatibilitate declarată cu WooCommerce 11 și cu Checkout-ul pe blocuri (Cart & Checkout Blocks).
 = 1.0 =
 Initial release
 == Upgrade Notice ==

--- a/woocommerce_digital_products/bt-ipay-payments.php
+++ b/woocommerce_digital_products/bt-ipay-payments.php
@@ -16,7 +16,7 @@
  * Plugin Name:       BT iPay Payments
  * Plugin URI:        https://btepos.ro/module-ecommerce
  * Description:       Extinde WooCommerce cu plata prin <strong>iPay BT</strong>. Pentru conectare aveti nevoie de credentiale API de la Banca Transilvania. Pentru detalii aplicatiiecommerce@btrl.ro
- * Version:           1.0.6
+ * Version:           1.0.7
  * Author:            Banca Transilvania
  * Author URI:        https://btepos.ro/module-ecommerce/
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@
  * Domain Path:       /languages
  * Requires Plugins:  woocommerce
  * WC requires at least: 7.0
- * WC tested up to: 8.7
+ * WC tested up to: 11.0
  */
 
 // If this file is called directly, abort.
@@ -38,7 +38,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'BT_IPAY_VERSION', '1.0.6' );
+define( 'BT_IPAY_VERSION', '1.0.7' );
 
 define( 'BT_IPAY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
@@ -90,6 +90,7 @@ bt_ipay_run();
 add_action( 'before_woocommerce_init', function() {
 	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
 	}
 } );
 

--- a/woocommerce_digital_products/bt-ipay.php
+++ b/woocommerce_digital_products/bt-ipay.php
@@ -24,7 +24,7 @@
  * Text Domain:       ipay
  * Domain Path:       /languages
  * WC requires at least: 7.0
- * WC tested up to: 8.7
+ * WC tested up to: 11.0
  */
 
 // If this file is called directly, abort.
@@ -89,5 +89,6 @@ run_bt_ipay();
 add_action( 'before_woocommerce_init', function() {
 	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
 	}
 } );


### PR DESCRIPTION
## Context

A merchant reported being unable to update to WooCommerce 11.0.1, believing BT iPay was incompatible and treating it as a security risk (blocked from applying WooCommerce security fixes).

**There was no functional incompatibility.** The plugin header still advertised `WC tested up to: 8.7`, which makes WooCommerce render the "not tested with your version of WooCommerce" warning on the plugins screen. That is declarative metadata — WordPress does not block the update because of it.

## Verification

Tested on a live store running WooCommerce 11.0.1 with the plugin active:

- Activates with no fatals and no PHP deprecations.
- Gateway registers (`bt-ipay` → `Bt_Ipay_Gateway`), `is_available()` true, `refunds` supported.
- HPOS: WooCommerce reports the plugin as **compatible**; no `post_meta` access for orders anywhere in the codebase.
- Block checkout: `bt-ipay` present in WooCommerce's block payment-method registry.
- All 12 `wc_*` functions and 4 `WC_*` classes referenced by the plugin still exist in 11.0.1.
- Storefront pages (home, cart, checkout) return 200/302 with no fatals.

## Changes

- `WC tested up to: 8.7` → `11.0` in all three bootstraps.
- Declare `cart_checkout_blocks` compatibility. The block integration already worked, but without the declaration WooCommerce classified the plugin as *uncertain* for that feature, producing a second warning.
- Version bump `1.0.6` → `1.0.7` (header, `BT_IPAY_VERSION`, `README.txt` `Stable tag`) plus a changelog entry.
- Applied to both plugin trees per the repo convention. The legacy `woocommerce_digital_products/bt-ipay.php` bootstrap gets the compat lines but stays at `1.0.0`.
- `woocommerce_digital_products/README.txt` had drifted to `Stable tag: 1.0.3` while its plugin file said 1.0.6; resynced with the main tree, which it otherwise matches byte for byte.

## Release note

`README.txt`'s `Stable tag` drives `.github/workflows/svn-sync.yml`, so merging this and creating a GitHub release will publish 1.0.7 to wordpress.org.

The changelog jumps from `1.0` straight to `1.0.7` — entries for 1.0.1–1.0.6 were never written and are not backfilled here.